### PR TITLE
dockerregistry-creds: Set a default namespace

### DIFF
--- a/add-k8sns-dockerregistry-creds/action.yaml
+++ b/add-k8sns-dockerregistry-creds/action.yaml
@@ -17,7 +17,8 @@ description: >
 inputs:
   k8sNS:
     description: Kubernetes Namespace
-    required: true
+    required: false
+    default: default
   secretName:
     description: Name for the new secret
     required: true


### PR DESCRIPTION
Using the same value as Kubernetes, so that we reduce the amount of parameters we need to deal with.