### PR TITLE
DO-1953 Upload license report to GitHub Release (optional)

### DIFF
--- a/oss-license-check-docker/action.yaml
+++ b/oss-license-check-docker/action.yaml
@@ -12,6 +12,9 @@ description: |
     with:
       dockerImage: "ghcr.io/midokura/docker-image:dev"
       runScancodeToolkit: true
+      githubToken: <secrets.TOKEN_PACKAGES>
+      repository: midokura/repository
+      tag: "1.0.2"
   ```
 
 inputs:
@@ -24,6 +27,18 @@ inputs:
     required: false
     type: boolean
     default: false
+  githubToken:
+    description: GitHub repo access token
+    required: false
+    type: string
+  repository:
+    description: GitHub repository in ORG/NAME format (midokura/...)
+    required: false
+    type: string
+  tag:
+    description: Tag name (default if not provided)
+    required: false
+    type: string
 
 runs:
   using: composite
@@ -106,6 +121,7 @@ runs:
           rm -f bom
           bom version
         fi
+
     - name: Run BOM
       shell: bash
       env:
@@ -114,11 +130,15 @@ runs:
         OUTPUT: bom.json
       run: bom generate --output=${OUTPUT} --format=${FORMAT} --image ${IMAGE_NAME}
 
-    # TODO: Update
-    # Report
-    - uses: actions/upload-artifact@v3
+    - name: Create tar.gz archive
+      run: tar czvf license-report-docker.tar.gz *.json
+
+    - name: Upload report files
+      if: inputs.tag != '' && inputs.githubToken != '' && inputs.repository != ''
+      uses: svenstaro/upload-release-action@v2
       with:
-        name: report
-        path: ./**.json
-        if-no-files-found: error
-        retention-days: 3
+        repo_name: ${{ inputs.repository }}
+        repo_token: ${{ inputs.githubToken }}
+        file: license-report-docker.tar.gz
+        asset_name: license-report-docker.tar.gz
+        tag: ${{ inputs.tag }}

--- a/oss-license-check-libs/action.yaml
+++ b/oss-license-check-libs/action.yaml
@@ -16,6 +16,7 @@ description: |
       fossologyEndpoint: https://fossology.domain.com/repo
       fossologyToken: <secrets.FOSSOLOGY_TOKEN>
       fossologyFolderId: "4"
+      tag: "1.0.2"
   ```
 
 inputs:
@@ -42,6 +43,10 @@ inputs:
   fossologyFolderId:
     description: Fossology folder ID
     required: true
+    type: string
+  tag:
+    description: Tag name (default if not provided)
+    required: false
     type: string
 
 runs:
@@ -170,16 +175,17 @@ runs:
         mkdir -p ${REPORT_FOLDER}
         echo "REPORT_FOLDER=${REPORT_FOLDER}" >> ${GITHUB_ENV}
         cp -v {upload,licenses}.json repository.txt ${REPORT_FOLDER}
+        tar -czvf license-report-libs.tar.gz -C ${REPORT_FOLDER} .
 
-    # TODO: Update
-    # Report
-    - name: Upload report
-      uses: actions/upload-artifact@v3
+    - name: Upload report files
+      if: inputs.tag != ''
+      uses: svenstaro/upload-release-action@v2
       with:
-        name: report
-        path: ${{ env.REPORT_FOLDER }}/
-        if-no-files-found: error
-        retention-days: 3
+        repo_name: ${{ inputs.repository }}
+        repo_token: ${{ inputs.githubToken }}
+        file: license-report-libs.tar.gz
+        asset_name: license-report-libs.tar.gz
+        tag: ${{ inputs.tag }}
 
     - name: Delete upload
       if: ${{ always() && steps.upload.outputs.id }}


### PR DESCRIPTION
## Changelog
- Add new optional parameter called `tag`
- Create tar with the report
- If `tag` is present, upload the tar to the github release
## Testing
https://github.com/midokura/gha-playground/releases/tag/1.0