### PR TITLE
DO-1987 Override assets uploaded to the github release

### DIFF
--- a/oss-license-check-docker/action.yaml
+++ b/oss-license-check-docker/action.yaml
@@ -142,4 +142,5 @@ runs:
         repo_token: ${{ inputs.githubToken }}
         file: license-report-docker.tar.gz
         asset_name: license-report-docker.tar.gz
+        overwrite: true
         tag: ${{ inputs.tag }}

--- a/oss-license-check-libs/action.yaml
+++ b/oss-license-check-libs/action.yaml
@@ -185,6 +185,7 @@ runs:
         repo_token: ${{ inputs.githubToken }}
         file: license-report-libs.tar.gz
         asset_name: license-report-libs.tar.gz
+        overwrite: true
         tag: ${{ inputs.tag }}
 
     - name: Delete upload


### PR DESCRIPTION
According to the documentation
https://github.com/svenstaro/upload-release-action
I haven't test it but it's possible we need to add more permissions to the token we are using