### PR TITLE
Updated oss-license-check actions

### DIFF
--- a/oss-license-check-docker/action.yaml
+++ b/oss-license-check-docker/action.yaml
@@ -11,7 +11,7 @@ description: |
     uses: midokura/gha-devops/oss-license-check-docker@main
     with:
       dockerImage: "ghcr.io/midokura/docker-image:dev"
-      runScancodeToolkit: true
+      runScancodeToolkit: "true"
       githubToken: <secrets.TOKEN_PACKAGES>
       repository: midokura/repository
       tag: "1.0.2"
@@ -21,24 +21,19 @@ inputs:
   dockerImage:
     description: Docker image to scan
     required: true
-    type: string
   runScancodeToolkit:
     description: Run scancode-toolkit
     required: false
-    type: boolean
-    default: false
+    default: "false"
   githubToken:
     description: GitHub repo access token
     required: false
-    type: string
   repository:
     description: GitHub repository in ORG/NAME format (midokura/...)
     required: false
-    type: string
   tag:
     description: Tag name (default if not provided)
     required: false
-    type: string
 
 runs:
   using: composite
@@ -85,7 +80,7 @@ runs:
         source ternenv/bin/activate
         tern report -i ${IMAGE_NAME} -f ${FORMAT} -o ${OUTPUT}
     - name: Run Tern scancode-toolkit
-      if: ${{ inputs.runScancodeToolkit }}
+      if: ${{ inputs.runScancodeToolkit == 'true' }}
       continue-on-error: true
       shell: bash
       env:

--- a/oss-license-check-libs/action.yaml
+++ b/oss-license-check-libs/action.yaml
@@ -23,31 +23,24 @@ inputs:
   githubToken:
     description: GitHub repo access token
     required: true
-    type: string
   repository:
     description: GitHub repository in ORG/NAME format (midokura/...)
     required: true
-    type: string
   branch:
     description: Branch name (default if not provided)
     required: false
-    type: string
   fossologyEndpoint:
     description: Fossology endpoint
     required: true
-    type: string
   fossologyToken:
     description: Fossology access token
     required: true
-    type: string
   fossologyFolderId:
     description: Fossology folder ID
     required: true
-    type: string
   tag:
     description: Tag name (default if not provided)
     required: false
-    type: string
 
 runs:
   using: composite


### PR DESCRIPTION
According to https://github.com/actions/runner/issues/2238, all the input parameters for the shared actions ("composite" actions) are always threated as string, no matter the 'type' values so:

- I removed the 'type' definitions in the new oss-license-check actions because has no sense, all are strings (also, code aligned with the previous existent actions)
- Changed the default value and if statement comparision to check the value of   `inputs.runScancodeToolkit`


