### PR TITLE
Update chart deps workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*   @midokura/devops

--- a/.github/chart-renovate.json5
+++ b/.github/chart-renovate.json5
@@ -1,0 +1,21 @@
+{   
+    "branchPrefix": "chart-renovate/",
+    "prConcurrentLimit": 10,
+    "prHourlyLimit": 100,
+    "enabledManagers": [
+        "helm-values",  // https://docs.renovatebot.com/modules/manager/helm-values/#additional-information supports
+        "helmv3"
+    ],
+    "includePaths": [
+        "charts/scs/values.yaml",
+        "charts/scs/Chart.yaml"
+    ],
+    "packageRules": [
+        {
+            "matchManagers": ["helm-values", "helmv3"],
+            "matchDatasources": ["helm", "docker"],
+            "allowedVersions": "/^\\d+\\.\\d+\\.\\d-main-\\d+-[a-f0-9]{7,40}$/",
+            "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-main-(?<build>\\d+)-[a-f0-9]{7,40}$" 
+        }
+    ]
+}

--- a/.github/chart-renovate.json5
+++ b/.github/chart-renovate.json5
@@ -6,10 +6,6 @@
         "helm-values",  // https://docs.renovatebot.com/modules/manager/helm-values/#additional-information supports
         "helmv3"
     ],
-    "includePaths": [
-        "charts/scs/values.yaml",
-        "charts/scs/Chart.yaml"
-    ],
     "packageRules": [
         {
             "matchManagers": ["helm-values", "helmv3"],

--- a/.github/workflows/ci-update-helmchart-deps.yaml
+++ b/.github/workflows/ci-update-helmchart-deps.yaml
@@ -25,9 +25,9 @@ jobs:
         fetch-depth: 0
     - name: Action lint
       uses: raven-actions/actionlint@v2
-      with: 
+      with:
         files: '.github/workflows/update-helmchart-dependencies.yaml'
     - name: Validate renovate config
       uses: suzuki-shunsuke/github-action-renovate-config-validator@v1.0.1
-      with: 
+      with:
         config_file_path: .github/chart-renovate.json5

--- a/.github/workflows/ci-update-helmchart-deps.yaml
+++ b/.github/workflows/ci-update-helmchart-deps.yaml
@@ -26,3 +26,7 @@ jobs:
       uses: raven-actions/actionlint@v2
       with: 
         files: '.github/workflows/update-helmchart-dependencies.yaml'
+    - name: Validate renovate config
+      uses: suzuki-shunsuke/github-action-renovate-config-validator@v1.0.1
+      with: 
+        config_file_path: .github/chart-renovate.json5

--- a/.github/workflows/ci-update-helmchart-deps.yaml
+++ b/.github/workflows/ci-update-helmchart-deps.yaml
@@ -1,3 +1,4 @@
+---
 name: CI - Force renovate to inspect and upgrade relevant dependencies
 
 on:

--- a/.github/workflows/ci-update-helmchart-deps.yaml
+++ b/.github/workflows/ci-update-helmchart-deps.yaml
@@ -4,7 +4,15 @@ on:
   push:
     branches:
       - main  
+    paths:
+      - .github/workflows/update-helmchart-dependencies.yaml
+      - .github/workflows/ci-update-helmchart-deps.yaml
+      - .github/chart-renovate.json5
   pull_request:
+      paths:
+      - .github/workflows/update-helmchart-dependencies.yaml
+      - .github/workflows/ci-update-helmchart-deps.yaml
+      - .github/chart-renovate.json5
 
 jobs:
   ci:

--- a/.github/workflows/ci-update-helmchart-deps.yaml
+++ b/.github/workflows/ci-update-helmchart-deps.yaml
@@ -3,13 +3,13 @@ name: CI - Force renovate to inspect and upgrade relevant dependencies
 on:
   push:
     branches:
-      - main  
+      - main
     paths:
       - .github/workflows/update-helmchart-dependencies.yaml
       - .github/workflows/ci-update-helmchart-deps.yaml
       - .github/chart-renovate.json5
   pull_request:
-      paths:
+    paths:
       - .github/workflows/update-helmchart-dependencies.yaml
       - .github/workflows/ci-update-helmchart-deps.yaml
       - .github/chart-renovate.json5
@@ -23,6 +23,6 @@ jobs:
       with:
         fetch-depth: 0
     - name: Action lint
-      run: |
-        go install github.com/rhysd/actionlint/cmd/actionlint@latest
-        actionlint .github/workflows/update-helmchart-dependencies.yaml
+      uses: raven-actions/actionlint@v2
+      with: 
+        files: '.github/workflows/update-helmchart-dependencies.yaml'

--- a/.github/workflows/ci-update-helmchart-deps.yaml
+++ b/.github/workflows/ci-update-helmchart-deps.yaml
@@ -1,0 +1,20 @@
+name: CI - Force renovate to inspect and upgrade relevant dependencies
+
+on:
+  push:
+    branches:
+      - main  
+  pull_request:
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Action lint
+      run: |
+        go install github.com/rhysd/actionlint/cmd/actionlint@latest
+        actionlint .github/workflows/update-helmchart-dependencies.yaml

--- a/.github/workflows/update-helmchart-dependencies.yaml
+++ b/.github/workflows/update-helmchart-dependencies.yaml
@@ -8,6 +8,9 @@ on:
       registry:
         required: true
         type: string
+      include-paths:
+        required: true
+        type: string
     secrets:
       renovate-bot-pat:
         required: true
@@ -44,6 +47,7 @@ jobs:
           RENOVATE_REPOSITORIES: ${{ github.repository }}
           RENOVATE_USERNAME: "midojenkins[bot]"
           RENOVATE_GIT_AUTHOR: "midojenkins <midojenkins[bot]@users.noreply.github.com>"
+          RENOVATE_INCLUDE_PATHS: ${{ inputs.include-paths }}
           # Needed to only run renovate for the chart
           RENOVATE_FORCE: "true"
           RENOVATE_ONBOARDING: "false"

--- a/.github/workflows/update-helmchart-dependencies.yaml
+++ b/.github/workflows/update-helmchart-dependencies.yaml
@@ -32,6 +32,9 @@ jobs:
           repository: midokura/gha-devops
           ref: update-chart-deps-workflow
           path: reusable
+
+      - name: Debug
+        run: tree
         
       - name: Run Renovate
         uses: renovatebot/github-action@v40.2.10

--- a/.github/workflows/update-helmchart-dependencies.yaml
+++ b/.github/workflows/update-helmchart-dependencies.yaml
@@ -49,7 +49,7 @@ jobs:
           RENOVATE_ONBOARDING: "false"
           RENOVATE_REQUIRE_CONFIG: "ignored"
           RENOVATE_PLATFORM_COMMIT: "true"
-          LOG_LEVEL: "debug" # Too little info without it
+          LOG_LEVEL: "debug"  # Too little info without it
         with:
           configurationFile: reusable/.github/chart-renovate.json5
           token: ${{ secrets.renovate-bot-pat }}

--- a/.github/workflows/update-helmchart-dependencies.yaml
+++ b/.github/workflows/update-helmchart-dependencies.yaml
@@ -1,3 +1,4 @@
+---
 name: Force renovate to inspect and upgrade relevant dependencies
 on:
   workflow_call:

--- a/.github/workflows/update-helmchart-dependencies.yaml
+++ b/.github/workflows/update-helmchart-dependencies.yaml
@@ -35,10 +35,6 @@ jobs:
           repository: midokura/gha-devops
           ref: update-chart-deps-workflow
           path: reusable
-
-      - name: Debug
-        run: tree
-        
       - name: Run Renovate
         uses: renovatebot/github-action@v40.2.10
         env:
@@ -53,8 +49,7 @@ jobs:
           RENOVATE_ONBOARDING: "false"
           RENOVATE_REQUIRE_CONFIG: "ignored"
           RENOVATE_PLATFORM_COMMIT: "true"
-          # Set to debug for more traces
-          LOG_LEVEL: "${{ runner.debug == '1' && 'debug' || 'info' }}"
+          LOG_LEVEL: "debug" # Too little info without it
         with:
           configurationFile: reusable/.github/chart-renovate.json5
           token: ${{ secrets.renovate-bot-pat }}

--- a/.github/workflows/update-helmchart-dependencies.yaml
+++ b/.github/workflows/update-helmchart-dependencies.yaml
@@ -8,11 +8,10 @@ on:
       registry:
         required: true
         type: string
-      registry-user:
-        required: true
-        type: string
     secrets:
       renovate-bot-pat:
+        required: true
+      registry-user:
         required: true
       registry-password:
         required: true

--- a/.github/workflows/update-helmchart-dependencies.yaml
+++ b/.github/workflows/update-helmchart-dependencies.yaml
@@ -37,7 +37,7 @@ jobs:
         uses: renovatebot/github-action@v40.2.10
         env:
           # I needed to set this here or it wouldn't take the credentials in chart-renovate.json
-          RENOVATE_HOST_RULES: '[{"hostType": "docker", "matchHost": "${{ inputs.registry }}", "username": "${{ inputs.registry-user }}", "password":"${{ secrets.registry-password }}"}]'
+          RENOVATE_HOST_RULES: '[{"hostType": "docker", "matchHost": "${{ inputs.registry }}", "username": "${{ secrets.registry-user }}", "password":"${{ secrets.registry-password }}"}]'
           RENOVATE_REPOSITORIES: ${{ github.repository }}
           RENOVATE_USERNAME: "midojenkins[bot]"
           RENOVATE_GIT_AUTHOR: "midojenkins <midojenkins[bot]@users.noreply.github.com>"

--- a/.github/workflows/update-helmchart-dependencies.yaml
+++ b/.github/workflows/update-helmchart-dependencies.yaml
@@ -1,0 +1,48 @@
+name: Force renovate to inspect and upgrade relevant dependencies
+on:
+  workflow_call:
+    inputs:
+      config-path:
+        required: false
+        type: string
+      registry:
+        required: true
+        type: string
+      registry-user:
+        required: true
+        type: string
+    secrets:
+      renovate-bot-pat:
+        required: true
+      registry-password:
+        required: true
+
+concurrency: renovate-chart
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    environment: operations
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - uses: midokura/gha-devops/.github/chart-renovate.json5@update-chart-deps-workflow
+      - name: Run Renovate
+        uses: renovatebot/github-action@v40.2.10
+        env:
+          # I needed to set this here or it wouldn't take the credentials in chart-renovate.json
+          RENOVATE_HOST_RULES: '[{"hostType": "docker", "matchHost": "${{ inputs.registry }}", "username": "${{ inputs.registry-user }}", "password":"${{ secrets.registry-password }}"}]'
+          RENOVATE_REPOSITORIES: ${{ github.repository }}
+          RENOVATE_USERNAME: "midojenkins[bot]"
+          RENOVATE_GIT_AUTHOR: "midojenkins <midojenkins[bot]@users.noreply.github.com>"
+          # Needed to only run renovate for the chart
+          RENOVATE_FORCE: "true"
+          RENOVATE_ONBOARDING: "false"
+          RENOVATE_REQUIRE_CONFIG: "ignored"
+          RENOVATE_PLATFORM_COMMIT: "true"
+          # Set to debug for more traces
+          LOG_LEVEL: "${{ runner.debug == '1' && 'debug' || 'info' }}"
+        with:
+          configurationFile: midokura/gha-devops/.github/chart-renovate.json5
+          token: ${{ secrets.renovate-bot-pat }}

--- a/.github/workflows/update-helmchart-dependencies.yaml
+++ b/.github/workflows/update-helmchart-dependencies.yaml
@@ -26,7 +26,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - uses: midokura/gha-devops/.github/chart-renovate.json5@update-chart-deps-workflow
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          repository: midokura/gha-devops
+          ref: update-chart-deps-workflow
+          path: reusable
+        
       - name: Run Renovate
         uses: renovatebot/github-action@v40.2.10
         env:
@@ -43,5 +49,5 @@ jobs:
           # Set to debug for more traces
           LOG_LEVEL: "${{ runner.debug == '1' && 'debug' || 'info' }}"
         with:
-          configurationFile: midokura/gha-devops/.github/chart-renovate.json5
+          configurationFile: reusable/.github/chart-renovate.json5
           token: ${{ secrets.renovate-bot-pat }}

--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ Each folder contains, at least, 2 files:
 
 So, **if you have some doubt about one GitHub Action, please go to the [GitHub Actions Index file](./gha.md) and read the corresponding 'README.md' file**.
 
+
+## Reusable Workflows
+
+You can find the documentation for the reusable workflows in the [GitHub Workflows file](./reusable-workflows.md).
+
 ### Develop new GitHub Action
 
 To develop a new GitHub Action and have propper documentation, please, don't forget to add a new README.md file in the new action folder, with the contents of the next template:

--- a/reusable-workflows.md
+++ b/reusable-workflows.md
@@ -1,0 +1,37 @@
+# Reusable Workflows
+
+## Force renovate to inspect and upgrade relevant dependencies
+
+### Usage
+
+```yaml
+jobs:
+  renovate-reuse:
+    uses: midokura/gha-devops/.github/workflows/update-helmchart-dependencies.yaml@main
+    with:
+      registry: "cratrrlsprdartifactsgl.azurecr.io"
+      include-paths: "aitrios-core/values.yaml,values.yaml"
+    secrets:
+      registry-user: ${{ secrets.GDO_GAR_SCS_USERNAME }}
+      registry-password: ${{ secrets.GDO_GAR_SCS_PASSWORD }}
+      renovate-bot-pat: ${{ secrets.DEMO_RENOVATE_BOT_PAT }}
+```
+
+### Description
+
+This workflow will trigger a renovatebot iteration that will automatically update the
+images and chart versions of the paths in `include-paths`.
+
+To follow a common convention to automate only the tags that are not in development,
+it will only update tags that follow this regex: `^\d+\.\d+\.\d-main-\d+-[a-f0-9]{7,40}$`.
+For example, `1.8.2-main-637-a7de93b1`, where the values are: `{aitrios_version}-main-{commit_number}-{sha}`.
+
+#### Inputs
+
+|Input|Description|Required|Secret|
+|---|---|---|---|
+|`registry`|Registry where the chart images and dependencies are stored. In the version, only one registry is supported|yes|no|   |
+|`include-paths`|Comma-separated list of paths of the files it should try to update. The files shoud be either `values.yaml`s or `Chart.yaml`s.|yes|no|
+|`registry-user`|Username to login into the `registry`|yes|yes|
+|`registry-password`|Password to login into the `registry`|yes|yes|
+|`renovate-bot-pat`|GitHub PAT renove bot will use to create the Pull Requests|yes|yes|


### PR DESCRIPTION
DO-3109

Converting [ApiK8s renovate workflow](https://github.com/SonySemiconductorSolutions/EdgeAIPF.SmartCamera.ApiK8s/blob/developer_main/.github/workflows/cd-update-chart-images.yaml) into a reusable workflow to standardize it across all charts.

- Fetches repo code and workflow code.
- Runs renovate action with the `chart-renovate.json5` config.
- Authenticates the registry with the `registry-*` inputs.
- Only checks the files from the input `include-paths`
- Add README with docs.
- Add CI to automatically validate the renovate config and the workflow.